### PR TITLE
Double Support, Reworked Floating Point Scaling/Offset, Updated Vectornav Parameters

### DIFF
--- a/GopherCAN.c
+++ b/GopherCAN.c
@@ -841,21 +841,24 @@ static S8 encode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
     return CAN_SUCCESS;
 }
 
+double param_data_double = 0;
 // decode_parameter
 // extract and decode a parameter from CAN data field
 static S8 decode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length)
 {
     U64 value = 0;
     float value_fl = 0;
-
+    double value_double = 0;
     // reconstruct U64
     for (U8 i = 0; i < length; i++) {
-        if (param->ENC == LSB) {
-            value |= data[start + i] << (i * BITS_IN_BYTE);
-        } else if (param->ENC == MSB) {
-            value |= data[start + i] << ((length - 1 - i) * BITS_IN_BYTE);
-        } else return DECODING_ERR;
+    if (param->ENC == LSB) {
+        value |= ((U64)data[start + i]) << (i * BITS_IN_BYTE);
+    } else if (param->ENC == MSB) {
+        value |= ((U64)data[start + i]) << ((length - 1 - i) * BITS_IN_BYTE);
+    } else {
+        return DECODING_ERR;
     }
+}
 
     // restore original type
     switch (param->TYPE) {
@@ -905,10 +908,11 @@ static S8 decode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
             else if (length == 4) value_fl = (U32)value;
             else value_fl = value;
 #endif
-            ((FLOAT_CAN_STRUCT*)param)->data = (float) (value_fl * param->SCALE) + param->OFFSET;
+            ((FLOAT_CAN_STRUCT*)param)->data = (float) ((value_fl * param->SCALE) + param->OFFSET);
             break;
         case DOUBLE:
-            ((DOUBLE_CAN_STRUCT*)param)->data = (double) (value_fl * param->SCALE) + param->OFFSET;
+            value_double = value;
+            ((DOUBLE_CAN_STRUCT*)param)->data = (double) ((value_double * param->SCALE) + param->OFFSET);
             break;
         default:
             return DECODING_ERR;

--- a/GopherCAN.c
+++ b/GopherCAN.c
@@ -4,7 +4,7 @@
 
 #include "GopherCAN.h"
 #include "GopherCAN_network.h"
-
+#include <math.h>
 /*************************************************
  * STATIC FUNCTION PROTOTYPES
 *************************************************/
@@ -781,7 +781,7 @@ S8 send_group(U16 group_id)
 static S8 encode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length)
 {
     U64 value = 0;
-
+    float raw_encoding = 0;
     // apply quantization and store in U64
     // use scale = 1 if necessary to avoid divide by 0 due to truncation
     switch (param->TYPE) {
@@ -819,8 +819,12 @@ static S8 encode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
             break;
         case FLOATING:
             // send floats as signed values
-            value = (S64)( (((FLOAT_CAN_STRUCT*)param)->data - param->OFFSET) / param->SCALE );
+            raw_encoding = ( ((FLOAT_CAN_STRUCT*)param)->data - param->OFFSET ) / param->SCALE;
+            value = (U64)llround(raw_encoding);
             break;
+        case DOUBLE:
+            raw_encoding = ( ((DOUBLE_CAN_STRUCT*)param)->data - param->OFFSET ) / param->SCALE;
+            value = (U64)llround(raw_encoding);
         default:
             return ENCODING_ERR;
     }
@@ -896,13 +900,15 @@ static S8 decode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
                 else value_fl = value;
             }
 #else
-            if (length == 1) value_fl = (S8)value;
-            else if (length == 2) value_fl = (S16)value;
-            else if (length == 4) value_fl = (S32)value;
-            else if (length == 8) value_fl = (S64)value;
+            if (length == 1) value_fl = (U8)value;
+            else if (length == 2) value_fl = (U16)value;
+            else if (length == 4) value_fl = (U32)value;
             else value_fl = value;
 #endif
-            ((FLOAT_CAN_STRUCT*)param)->data = (value_fl * param->SCALE) + param->OFFSET;
+            ((FLOAT_CAN_STRUCT*)param)->data = (float) (value_fl * param->SCALE) + param->OFFSET;
+            break;
+        case DOUBLE:
+            ((DOUBLE_CAN_STRUCT*)param)->data = (double) (value_fl * param->SCALE) + param->OFFSET;
             break;
         default:
             return DECODING_ERR;

--- a/GopherCAN.c
+++ b/GopherCAN.c
@@ -4,7 +4,7 @@
 
 #include "GopherCAN.h"
 #include "GopherCAN_network.h"
-
+#include <math.h>
 /*************************************************
  * STATIC FUNCTION PROTOTYPES
 *************************************************/
@@ -788,7 +788,7 @@ S8 send_group(U16 group_id)
 static S8 encode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length)
 {
     U64 value = 0;
-
+    float raw_encoding = 0;
     // apply quantization and store in U64
     // use scale = 1 if necessary to avoid divide by 0 due to truncation
     switch (param->TYPE) {
@@ -826,8 +826,12 @@ static S8 encode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
             break;
         case FLOATING:
             // send floats as signed values
-            value = (S64)( (((FLOAT_CAN_STRUCT*)param)->data - param->OFFSET) / param->SCALE );
+            raw_encoding = ( ((FLOAT_CAN_STRUCT*)param)->data - param->OFFSET ) / param->SCALE;
+            value = (U64)llround(raw_encoding);
             break;
+        case DOUBLE:
+            raw_encoding = ( ((DOUBLE_CAN_STRUCT*)param)->data - param->OFFSET ) / param->SCALE;
+            value = (U64)llround(raw_encoding);
         default:
             return ENCODING_ERR;
     }
@@ -903,13 +907,15 @@ static S8 decode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
                 else value_fl = value;
             }
 #else
-            if (length == 1) value_fl = (S8)value;
-            else if (length == 2) value_fl = (S16)value;
-            else if (length == 4) value_fl = (S32)value;
-            else if (length == 8) value_fl = (S64)value;
+            if (length == 1) value_fl = (U8)value;
+            else if (length == 2) value_fl = (U16)value;
+            else if (length == 4) value_fl = (U32)value;
             else value_fl = value;
 #endif
-            ((FLOAT_CAN_STRUCT*)param)->data = (value_fl * param->SCALE) + param->OFFSET;
+            ((FLOAT_CAN_STRUCT*)param)->data = (float) (value_fl * param->SCALE) + param->OFFSET;
+            break;
+        case DOUBLE:
+            ((DOUBLE_CAN_STRUCT*)param)->data = (double) (value_fl * param->SCALE) + param->OFFSET;
             break;
         default:
             return DECODING_ERR;

--- a/GopherCAN.c
+++ b/GopherCAN.c
@@ -848,21 +848,24 @@ static S8 encode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
     return CAN_SUCCESS;
 }
 
+double param_data_double = 0;
 // decode_parameter
 // extract and decode a parameter from CAN data field
 static S8 decode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length)
 {
     U64 value = 0;
     float value_fl = 0;
-
+    double value_double = 0;
     // reconstruct U64
     for (U8 i = 0; i < length; i++) {
-        if (param->ENC == LSB) {
-            value |= data[start + i] << (i * BITS_IN_BYTE);
-        } else if (param->ENC == MSB) {
-            value |= data[start + i] << ((length - 1 - i) * BITS_IN_BYTE);
-        } else return DECODING_ERR;
+    if (param->ENC == LSB) {
+        value |= ((U64)data[start + i]) << (i * BITS_IN_BYTE);
+    } else if (param->ENC == MSB) {
+        value |= ((U64)data[start + i]) << ((length - 1 - i) * BITS_IN_BYTE);
+    } else {
+        return DECODING_ERR;
     }
+}
 
     // restore original type
     switch (param->TYPE) {
@@ -912,10 +915,11 @@ static S8 decode_parameter(CAN_INFO_STRUCT* param, U8* data, U8 start, U8 length
             else if (length == 4) value_fl = (U32)value;
             else value_fl = value;
 #endif
-            ((FLOAT_CAN_STRUCT*)param)->data = (float) (value_fl * param->SCALE) + param->OFFSET;
+            ((FLOAT_CAN_STRUCT*)param)->data = (float) ((value_fl * param->SCALE) + param->OFFSET);
             break;
         case DOUBLE:
-            ((DOUBLE_CAN_STRUCT*)param)->data = (double) (value_fl * param->SCALE) + param->OFFSET;
+            value_double = value;
+            ((DOUBLE_CAN_STRUCT*)param)->data = (double) ((value_double * param->SCALE) + param->OFFSET);
             break;
         default:
             return DECODING_ERR;

--- a/network_autogen/autogen.py
+++ b/network_autogen/autogen.py
@@ -18,7 +18,8 @@ param_structs = {
     "SIGNED16" : "S16_CAN_STRUCT",
     "SIGNED32" : "S32_CAN_STRUCT",
     "SIGNED64" : "S64_CAN_STRUCT",
-    "FLOATING" : "FLOAT_CAN_STRUCT"
+    "FLOATING" : "FLOAT_CAN_STRUCT",
+    "DOUBLE" : "DOUBLE_CAN_STRUCT"
 }
 
 filenames = [

--- a/network_autogen/configs/go4-26.yaml
+++ b/network_autogen/configs/go4-26.yaml
@@ -2168,7 +2168,7 @@ parameters:
         motec_name: FVC INS Status
         unit: none
         type: UNSIGNED16
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2176,27 +2176,27 @@ parameters:
         id: 229
         motec_name: FVC Latitude
         unit: deg
-        type: FLOATING
-        encoding: MSB
-        scale: 0.00549324788    # [-90 - 90] -> [0-32768]
+        type: DOUBLE
+        encoding: LSB
+        scale: 0.00000000000000000975781955236954    # [-90 - 90] -> [0-18,446,744,073,709,551,615]
         offset: -90
 
     vnavLongitude:
         id: 230
         motec_name: FVC Longitude
         unit: deg
-        type: FLOATING
-        encoding: MSB
-        scale: 0.01098633    # [-180 - 180] -> [0-32768]
+        type: DOUBLE
+        encoding: LSB
+        scale: 0.00000000000000001951563910473908    # [-180 - 180] -> [0-18,446,744,073,709,551,615]
         offset: -180
 
     vnavAltitude:
         id: 231
         motec_name: FVC Altitude
         unit: m
-        type: FLOATING
-        encoding: MSB
-        scale: 0.06103608758     # [-1000 - 3000] -> [0-65535]
+        type: DOUBLE
+        encoding: LSB
+        scale: 0.0000000000000002710505431213761    # [-1000 - 4000] -> [0-18,446,744,073,709,551,615]
         offset: -1000
 
     vnavVelBodyX:
@@ -2204,8 +2204,8 @@ parameters:
         motec_name: FVC Velocity Body X
         unit: m/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00427246    # [-70 - 70] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000032596290116    # [-70 - 70] -> [0-4,294,967,295]
         offset: -70
 
     vnavVelBodyY:
@@ -2213,8 +2213,8 @@ parameters:
         motec_name: FVC Velocity Body Y
         unit: m/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00427246   # [-70 - 70] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000032596290116   # [-70 - 70] -> [0-4,294,967,295]
         offset: -70
 
     vnavVelBodyZ:
@@ -2222,8 +2222,8 @@ parameters:
         motec_name: FVC Velocity Body Z
         unit: m/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00427246   # [-70 - 70] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000032596290116   # [-70 - 70] -> [0-4,294,967,295]
         offset: -70
 
     vnavYaw:
@@ -2231,8 +2231,8 @@ parameters:
         motec_name: FVC Yaw
         unit: deg
         type: FLOATING
-        encoding: MSB
-        scale: 0.000000167638063    # [-180 - 180] -> [0-65535]
+        encoding: LSB
+        scale: 0.000000083819031728    # [-180 - 180] -> [0-4,294,967,295]
         offset: -180
 
     vnavPitch:
@@ -2240,8 +2240,8 @@ parameters:
         motec_name: FVC Pitch
         unit: deg
         type: FLOATING
-        encoding: MSB
-        scale: 0.00549316406    # [-90 - 90] -> [0-65535]
+        encoding: LSB
+        scale: 0.000000041909515864    # [-90 - 90] -> [0-4,294,967,295]
         offset: -90
 
     vnavRoll:
@@ -2249,8 +2249,8 @@ parameters:
         motec_name: FVC Roll
         unit: deg
         type: FLOATING
-        encoding: MSB
-        scale: 0.01098632812    # [-180 - 180] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000083819031728    # [-180 - 180] -> [0-4,294,967,295]
         offset: -180
 
     vnavQuatX:
@@ -2258,8 +2258,8 @@ parameters:
         motec_name: FVC Quaternion X
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavQuatY:
@@ -2267,8 +2267,8 @@ parameters:
         motec_name: FVC Quaternion Y
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavQuatZ:
@@ -2276,8 +2276,8 @@ parameters:
         motec_name: FVC Quaternion Z
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavQuatS:
@@ -2285,8 +2285,8 @@ parameters:
         motec_name: FVC Quaternion Scalar
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavLinBodyAccX:
@@ -2294,8 +2294,8 @@ parameters:
         motec_name: FVC Linear Acc Body X
         unit: m/s^2
         type: FLOATING
-        encoding: MSB
-        scale: 0.00305175781   # [-50 - 50] -> [0 - 32768]
+        encoding: LSB
+        scale: 0.000000023283064375   # [-50 - 50] -> [0 - 4,294,967,295]
         offset: -50
 
     vnavLinBodyAccY:
@@ -2303,8 +2303,8 @@ parameters:
         motec_name: FVC Linear Acc Body Y
         unit: m/s^2
         type: FLOATING
-        encoding: MSB
-        scale: 0.00305175781  # [-50 - 50] -> [0 - 32768]
+        encoding: LSB
+        scale: 0.000000023283064375  # [-50 - 50] -> [0 - 4,294,967,295]
         offset: -50
 
     vnavLinBodyAccZ:
@@ -2312,8 +2312,8 @@ parameters:
         motec_name: FVC Linear Acc Body Z
         unit: m/s^2
         type: FLOATING
-        encoding: MSB
-        scale: 0.00305175781  # [-50 - 50] -> [0 - 32768]
+        encoding: LSB
+        scale: 0.000000023283064375  # [-50 - 50] -> [0 - 4,294,967,295]
         offset: -50
 
     vnavTimeUtcY:
@@ -2321,7 +2321,7 @@ parameters:
         motec_name: FVC UTC Year
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2330,7 +2330,7 @@ parameters:
         motec_name: FVC UTC Month
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2339,7 +2339,7 @@ parameters:
         motec_name: FVC UTC Day
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2348,7 +2348,7 @@ parameters:
         motec_name: FVC UTC Hour
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2357,7 +2357,7 @@ parameters:
         motec_name: FVC UTC Minute
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2366,7 +2366,7 @@ parameters:
         motec_name: FVC UTC Second
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2375,7 +2375,7 @@ parameters:
         motec_name: FVC UTC Fraction
         unit: none
         type: UNSIGNED16
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2384,8 +2384,8 @@ parameters:
         motec_name: FVC Gyro Body X
         unit: deg/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00000186264514923095703125 #[-2000 -> 2000] -> [0 -> 2147483648]
+        encoding: LSB
+        scale: 0.000000931322574847 #[-2000 -> 2000] -> [0 -> 4,294,967,295]
         offset: -2000
 
     vnavGyroBodyY:
@@ -2393,8 +2393,8 @@ parameters:
         motec_name: FVC Gyro Body Y
         unit: deg/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00000186264514923095703125    #[-2000 -> 2000] -> [0 -> 2147483648]
+        encoding: LSB
+        scale: 0.000000931322574847   #[-2000 -> 2000] -> [0 -> 4,294,967,295]
         offset: -2000
 
     vnavGyroBodyZ:
@@ -2402,8 +2402,8 @@ parameters:
         motec_name: FVC Gyro Body Z
         unit: deg/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00000186264514923095703125   #[-2000 -> 2000] -> [0 -> 2147483648]
+        encoding: LSB
+        scale: 0.000000931322574847   #[-2000 -> 2000] -> [0 -> 4,294,967,295]
         offset: -2000
     # END Vector NAV CAN Module
 
@@ -7545,49 +7545,69 @@ groups: [
     # END RVC
 
     # Vector NAV CAN Module
+    
     {
         id: 0x200,
         parameters: [
-            {name: vnavINS_status,     start: 0, length: 2},
-            {name: vnavVelBodyX,       start: 2, length: 2},
-            {name: vnavVelBodyY,       start: 4, length: 2},
-            {name: vnavVelBodyZ,       start: 6, length: 2}
+            {name: vnavLatitude,     start: 0, length: 8},
         ]
     },
     {
         id: 0x201,
         parameters: [
-            {name: vnavLatitude,     start: 0, length: 4},
-            {name: vnavLongitude,    start: 4, length: 4}
+            {name: vnavLongitude,    start: 0, length: 8}
         ]
     },
     {
         id: 0x202,
         parameters: [
-            {name: vnavYaw,     start: 0, length: 4},
-            {name: vnavPitch,   start: 4, length: 2},
-            {name: vnavRoll,    start: 6, length: 2}
+            {name: vnavAltitude,    start: 0, length: 8}
         ]
     },
     {
         id: 0x203,
         parameters: [
-            {name: vnavQuatX,    start: 0, length: 2},
-            {name: vnavQuatY,    start: 2, length: 2},
-            {name: vnavQuatZ,    start: 4, length: 2},
-            {name: vnavQuatS,    start: 6, length: 2}
+            {name: vnavVelBodyX,       start: 0, length: 4},
+            {name: vnavVelBodyY,       start: 4, length: 4},
         ]
     },
     {
         id: 0x204,
         parameters: [
-            {name: vnavLinBodyAccX,    start: 0, length: 2},
-            {name: vnavLinBodyAccY,    start: 2, length: 2},
-            {name: vnavLinBodyAccZ,    start: 4, length: 2}
+            {name: vnavYaw,     start: 0, length: 4},
+            {name: vnavPitch,   start: 4, length: 4}
         ]
     },
     {
         id: 0x205,
+        parameters: [
+            {name: vnavRoll,           start: 0, length: 4},
+            {name: vnavLinBodyAccZ,    start: 4, length: 4}
+        ]
+    },
+    {
+        id: 0x204,
+        parameters: [
+            {name: vnavLinBodyAccX,    start: 0, length: 4},
+            {name: vnavLinBodyAccY,    start: 4, length: 4}
+        ]
+    },
+    {
+        id: 0x204,
+        parameters: [
+            {name: vnavQuatX,    start: 0, length: 4},
+            {name: vnavQuatY,    start: 4, length: 4},
+        ]
+    },
+    {
+        id: 0x205,
+        parameters: [
+            {name: vnavQuatZ,    start: 0, length: 4},
+            {name: vnavQuatS,    start: 4, length: 4}
+        ]
+    },
+    {
+        id: 0x206,
         parameters: [
             {name: vnavTimeUtcY,     start: 0, length: 1},
             {name: vnavTimeUtcMonth, start: 1, length: 1},
@@ -7599,17 +7619,23 @@ groups: [
         ]
     },
     {
-        id: 0x206,
+        id: 0x207,
         parameters: [
             {name: vnavGyroBodyX,     start: 0, length: 4},
             {name: vnavGyroBodyY,     start: 4, length: 4},
         ]
     },
     {
-        id: 0x207,
+        id: 0x208,
         parameters: [
             {name: vnavGyroBodyZ,     start: 0, length: 4},
-            {name: vnavAltitude,     start: 5,     length: 2}
+            {name: vnavINS_status,    start: 4, length: 2},
+        ]
+    },
+    {
+        id: 0x209,
+        parameters: [
+            {name: vnavVelBodyZ,     start: 0, length: 4}
         ]
     },
 

--- a/network_autogen/configs/go4-26.yaml
+++ b/network_autogen/configs/go4-26.yaml
@@ -2166,7 +2166,7 @@ parameters:
         motec_name: FVC INS Status
         unit: none
         type: UNSIGNED16
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2174,27 +2174,27 @@ parameters:
         id: 229
         motec_name: FVC Latitude
         unit: deg
-        type: FLOATING
-        encoding: MSB
-        scale: 0.00549324788    # [-90 - 90] -> [0-32768]
+        type: DOUBLE
+        encoding: LSB
+        scale: 0.00000000000000000975781955236954    # [-90 - 90] -> [0-18,446,744,073,709,551,615]
         offset: -90
 
     vnavLongitude:
         id: 230
         motec_name: FVC Longitude
         unit: deg
-        type: FLOATING
-        encoding: MSB
-        scale: 0.01098633    # [-180 - 180] -> [0-32768]
+        type: DOUBLE
+        encoding: LSB
+        scale: 0.00000000000000001951563910473908    # [-180 - 180] -> [0-18,446,744,073,709,551,615]
         offset: -180
 
     vnavAltitude:
         id: 231
         motec_name: FVC Altitude
         unit: m
-        type: FLOATING
-        encoding: MSB
-        scale: 0.06103608758     # [-1000 - 3000] -> [0-65535]
+        type: DOUBLE
+        encoding: LSB
+        scale: 0.0000000000000002710505431213761    # [-1000 - 4000] -> [0-18,446,744,073,709,551,615]
         offset: -1000
 
     vnavVelBodyX:
@@ -2202,8 +2202,8 @@ parameters:
         motec_name: FVC Velocity Body X
         unit: m/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00427246    # [-70 - 70] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000032596290116    # [-70 - 70] -> [0-4,294,967,295]
         offset: -70
 
     vnavVelBodyY:
@@ -2211,8 +2211,8 @@ parameters:
         motec_name: FVC Velocity Body Y
         unit: m/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00427246   # [-70 - 70] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000032596290116   # [-70 - 70] -> [0-4,294,967,295]
         offset: -70
 
     vnavVelBodyZ:
@@ -2220,8 +2220,8 @@ parameters:
         motec_name: FVC Velocity Body Z
         unit: m/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00427246   # [-70 - 70] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000032596290116   # [-70 - 70] -> [0-4,294,967,295]
         offset: -70
 
     vnavYaw:
@@ -2229,8 +2229,8 @@ parameters:
         motec_name: FVC Yaw
         unit: deg
         type: FLOATING
-        encoding: MSB
-        scale: 0.000000167638063    # [-180 - 180] -> [0-65535]
+        encoding: LSB
+        scale: 0.000000083819031728    # [-180 - 180] -> [0-4,294,967,295]
         offset: -180
 
     vnavPitch:
@@ -2238,8 +2238,8 @@ parameters:
         motec_name: FVC Pitch
         unit: deg
         type: FLOATING
-        encoding: MSB
-        scale: 0.00549316406    # [-90 - 90] -> [0-65535]
+        encoding: LSB
+        scale: 0.000000041909515864    # [-90 - 90] -> [0-4,294,967,295]
         offset: -90
 
     vnavRoll:
@@ -2247,8 +2247,8 @@ parameters:
         motec_name: FVC Roll
         unit: deg
         type: FLOATING
-        encoding: MSB
-        scale: 0.01098632812    # [-180 - 180] -> [0-32768]
+        encoding: LSB
+        scale: 0.000000083819031728    # [-180 - 180] -> [0-4,294,967,295]
         offset: -180
 
     vnavQuatX:
@@ -2256,8 +2256,8 @@ parameters:
         motec_name: FVC Quaternion X
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavQuatY:
@@ -2265,8 +2265,8 @@ parameters:
         motec_name: FVC Quaternion Y
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavQuatZ:
@@ -2274,8 +2274,8 @@ parameters:
         motec_name: FVC Quaternion Z
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavQuatS:
@@ -2283,8 +2283,8 @@ parameters:
         motec_name: FVC Quaternion Scalar
         unit: none
         type: FLOATING
-        encoding: MSB
-        scale: 0.00006103515    # [-1 -> 1] -> [0 -> 32768]
+        encoding: LSB
+        scale: 0.000000000465661287524    # [-1 -> 1] -> [0 -> 4,294,967,295]
         offset: -1
 
     vnavLinBodyAccX:
@@ -2292,8 +2292,8 @@ parameters:
         motec_name: FVC Linear Acc Body X
         unit: m/s^2
         type: FLOATING
-        encoding: MSB
-        scale: 0.00305175781   # [-50 - 50] -> [0 - 32768]
+        encoding: LSB
+        scale: 0.000000023283064375   # [-50 - 50] -> [0 - 4,294,967,295]
         offset: -50
 
     vnavLinBodyAccY:
@@ -2301,8 +2301,8 @@ parameters:
         motec_name: FVC Linear Acc Body Y
         unit: m/s^2
         type: FLOATING
-        encoding: MSB
-        scale: 0.00305175781  # [-50 - 50] -> [0 - 32768]
+        encoding: LSB
+        scale: 0.000000023283064375  # [-50 - 50] -> [0 - 4,294,967,295]
         offset: -50
 
     vnavLinBodyAccZ:
@@ -2310,8 +2310,8 @@ parameters:
         motec_name: FVC Linear Acc Body Z
         unit: m/s^2
         type: FLOATING
-        encoding: MSB
-        scale: 0.00305175781  # [-50 - 50] -> [0 - 32768]
+        encoding: LSB
+        scale: 0.000000023283064375  # [-50 - 50] -> [0 - 4,294,967,295]
         offset: -50
 
     vnavTimeUtcY:
@@ -2319,7 +2319,7 @@ parameters:
         motec_name: FVC UTC Year
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2328,7 +2328,7 @@ parameters:
         motec_name: FVC UTC Month
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2337,7 +2337,7 @@ parameters:
         motec_name: FVC UTC Day
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2346,7 +2346,7 @@ parameters:
         motec_name: FVC UTC Hour
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2355,7 +2355,7 @@ parameters:
         motec_name: FVC UTC Minute
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2364,7 +2364,7 @@ parameters:
         motec_name: FVC UTC Second
         unit: none
         type: UNSIGNED8
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2373,7 +2373,7 @@ parameters:
         motec_name: FVC UTC Fraction
         unit: none
         type: UNSIGNED16
-        encoding: MSB
+        encoding: LSB
         scale: 1
         offset: 0
 
@@ -2382,8 +2382,8 @@ parameters:
         motec_name: FVC Gyro Body X
         unit: deg/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00000186264514923095703125 #[-2000 -> 2000] -> [0 -> 2147483648]
+        encoding: LSB
+        scale: 0.000000931322574847 #[-2000 -> 2000] -> [0 -> 4,294,967,295]
         offset: -2000
 
     vnavGyroBodyY:
@@ -2391,8 +2391,8 @@ parameters:
         motec_name: FVC Gyro Body Y
         unit: deg/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00000186264514923095703125    #[-2000 -> 2000] -> [0 -> 2147483648]
+        encoding: LSB
+        scale: 0.000000931322574847   #[-2000 -> 2000] -> [0 -> 4,294,967,295]
         offset: -2000
 
     vnavGyroBodyZ:
@@ -2400,8 +2400,8 @@ parameters:
         motec_name: FVC Gyro Body Z
         unit: deg/s
         type: FLOATING
-        encoding: MSB
-        scale: 0.00000186264514923095703125   #[-2000 -> 2000] -> [0 -> 2147483648]
+        encoding: LSB
+        scale: 0.000000931322574847   #[-2000 -> 2000] -> [0 -> 4,294,967,295]
         offset: -2000
     # END Vector NAV CAN Module
 
@@ -7750,49 +7750,69 @@ groups: [
     # END RVC
 
     # Vector NAV CAN Module
+    
     {
         id: 0x200,
         parameters: [
-            {name: vnavINS_status,     start: 0, length: 2},
-            {name: vnavVelBodyX,       start: 2, length: 2},
-            {name: vnavVelBodyY,       start: 4, length: 2},
-            {name: vnavVelBodyZ,       start: 6, length: 2}
+            {name: vnavLatitude,     start: 0, length: 8},
         ]
     },
     {
         id: 0x201,
         parameters: [
-            {name: vnavLatitude,     start: 0, length: 4},
-            {name: vnavLongitude,    start: 4, length: 4}
+            {name: vnavLongitude,    start: 0, length: 8}
         ]
     },
     {
         id: 0x202,
         parameters: [
-            {name: vnavYaw,     start: 0, length: 4},
-            {name: vnavPitch,   start: 4, length: 2},
-            {name: vnavRoll,    start: 6, length: 2}
+            {name: vnavAltitude,    start: 0, length: 8}
         ]
     },
     {
         id: 0x203,
         parameters: [
-            {name: vnavQuatX,    start: 0, length: 2},
-            {name: vnavQuatY,    start: 2, length: 2},
-            {name: vnavQuatZ,    start: 4, length: 2},
-            {name: vnavQuatS,    start: 6, length: 2}
+            {name: vnavVelBodyX,       start: 0, length: 4},
+            {name: vnavVelBodyY,       start: 4, length: 4},
         ]
     },
     {
         id: 0x204,
         parameters: [
-            {name: vnavLinBodyAccX,    start: 0, length: 2},
-            {name: vnavLinBodyAccY,    start: 2, length: 2},
-            {name: vnavLinBodyAccZ,    start: 4, length: 2}
+            {name: vnavYaw,     start: 0, length: 4},
+            {name: vnavPitch,   start: 4, length: 4}
         ]
     },
     {
         id: 0x205,
+        parameters: [
+            {name: vnavRoll,           start: 0, length: 4},
+            {name: vnavLinBodyAccZ,    start: 4, length: 4}
+        ]
+    },
+    {
+        id: 0x204,
+        parameters: [
+            {name: vnavLinBodyAccX,    start: 0, length: 4},
+            {name: vnavLinBodyAccY,    start: 4, length: 4}
+        ]
+    },
+    {
+        id: 0x204,
+        parameters: [
+            {name: vnavQuatX,    start: 0, length: 4},
+            {name: vnavQuatY,    start: 4, length: 4},
+        ]
+    },
+    {
+        id: 0x205,
+        parameters: [
+            {name: vnavQuatZ,    start: 0, length: 4},
+            {name: vnavQuatS,    start: 4, length: 4}
+        ]
+    },
+    {
+        id: 0x206,
         parameters: [
             {name: vnavTimeUtcY,     start: 0, length: 1},
             {name: vnavTimeUtcMonth, start: 1, length: 1},
@@ -7804,17 +7824,23 @@ groups: [
         ]
     },
     {
-        id: 0x206,
+        id: 0x207,
         parameters: [
             {name: vnavGyroBodyX,     start: 0, length: 4},
             {name: vnavGyroBodyY,     start: 4, length: 4},
         ]
     },
     {
-        id: 0x207,
+        id: 0x208,
         parameters: [
             {name: vnavGyroBodyZ,     start: 0, length: 4},
-            {name: vnavAltitude,     start: 5,     length: 2}
+            {name: vnavINS_status,    start: 4, length: 2},
+        ]
+    },
+    {
+        id: 0x209,
+        parameters: [
+            {name: vnavVelBodyZ,     start: 0, length: 4}
         ]
     },
 

--- a/network_autogen/templates/GopherCAN_network.h.jinja2
+++ b/network_autogen/templates/GopherCAN_network.h.jinja2
@@ -30,7 +30,8 @@ typedef enum {
     SIGNED16 = 6,
     SIGNED32 = 7,
     SIGNED64 = 8,
-    FLOATING = 9
+    FLOATING = 9,
+    DOUBLE   = 10
 } DATATYPES;
 
 typedef enum {
@@ -44,7 +45,8 @@ typedef enum {
     SIGNED16_SIZE = 2,
     SIGNED32_SIZE = 4,
     SIGNED64_SIZE = 8,
-    FLOATING_SIZE = 4
+    FLOATING_SIZE = 4,
+    DOUBLE_SIZE   = 8
 } DATATYPES_SIZE;
 
 // *** MESSAGE BUFFERS ***
@@ -171,6 +173,11 @@ typedef struct {
     CAN_INFO_STRUCT info;
     float data;
 } FLOAT_CAN_STRUCT;
+
+typedef struct {
+    CAN_INFO_STRUCT info;
+    double data;
+} DOUBLE_CAN_STRUCT;
 
 {% for id, value in parameters.items() -%}
 extern {{ param_structs[value.type] }} {{ value.name }};


### PR DESCRIPTION
Giving go4-26 the ability to send 8 byte double data onto any can bus, changing double/floating point scaling and offset scheme to used unsigned integers instead of signed, giving new ids and formatting to vectornav parameters.